### PR TITLE
Installing the Calico add-on fix

### DIFF
--- a/doc_source/calico.md
+++ b/doc_source/calico.md
@@ -9,6 +9,10 @@
 
 **Prerequisites**
 + An existing Amazon EKS cluster\. To deploy one, see [Getting started with Amazon EKS](getting-started.md)\.
++ Be sure to enable CNI plugin i.e. set the ENABLE_POD_ENI variable to true in the aws-node DaemonSet.
+```
+kubectl -n kube-system set env daemonset aws-node ENABLE_POD_ENI=true
+```
 + The `kubectl` command line tool installed on your computer or AWS CloudShell\. The version must be the same, or up to two versions later than your cluster version\. To install or upgrade `kubectl`, see [Installing `kubectl`](install-kubectl.md)\.
 
 The following procedure shows you how to install Calico on Linux nodes in your Amazon EKS cluster\. To install Calico on Windows nodes, see [Using Calico on Amazon EKS Windows Containers](http://aws.amazon.com/blogs/containers/open-source-calico-for-windows-containers-on-amazon-eks/)\.


### PR DESCRIPTION
Network Policies with Calico project are based upon AWS CNI as stated "To enable Calico network policy enforcement on an EKS cluster using the AWS VPC CNI plugin, follow these step-by-step instructions" in 
https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
